### PR TITLE
Add linux-armv6k for raspberry pi zero

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -14,6 +14,11 @@
 
 package(default_visibility = ["//visibility:public"])
 
+constraint_value(
+    name = "armv6k",
+    constraint_setting = "@platforms//cpu:cpu",
+)
+
 platform(
     name = "linux-x86_64",
     constraint_values = [
@@ -27,6 +32,14 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
+    ],
+)
+
+platform(
+    name = "linux-armv6k",
+    constraint_values = [
+        "@platforms//os:linux",
+        "//platforms:armv6k",
     ],
 )
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -59,6 +59,9 @@ def cc_toolchain_config(
         compiler,
         abi_version,
         abi_libc_version,
+        target_cpu_variant,
+        target_fpu,
+        target_float_abi
     ) = {
         "darwin-x86_64": (
             "clang-x86_64-darwin",
@@ -68,6 +71,9 @@ def cc_toolchain_config(
             "clang",
             "darwin_x86_64",
             "darwin_x86_64",
+            "unknown",
+            "unknown",
+            "unknown",
         ),
         "darwin-aarch64": (
             "clang-aarch64-darwin",
@@ -77,6 +83,9 @@ def cc_toolchain_config(
             "clang",
             "darwin_aarch64",
             "darwin_aarch64",
+            "unknown",
+            "unknown",
+            "unknown",
         ),
         "linux-aarch64": (
             "clang-aarch64-linux",
@@ -86,6 +95,21 @@ def cc_toolchain_config(
             "clang",
             "clang",
             "glibc_unknown",
+            "unknown",
+            "unknown",
+            "unknown",
+        ),
+        "linux-armv6k": (
+            "clang-armv6k-linux",
+            "armv6k-unknown-linux-gnueabihf",
+            "armv6k",
+            "glibc_unknown",
+            "clang",
+            "clang",
+            "glibc_unknown",
+            "arm1176jzf-s",
+            "vfp",
+            "hard",
         ),
         "linux-x86_64": (
             "clang-x86_64-linux",
@@ -95,6 +119,9 @@ def cc_toolchain_config(
             "clang",
             "clang",
             "glibc_unknown",
+            "unknown",
+            "unknown",
+            "unknown",
         ),
     }[target_os_arch_key]
 
@@ -127,6 +154,22 @@ def cc_toolchain_config(
         "-Wthread-safety",
         "-Wself-assign",
     ]
+
+    if target_cpu_variant != "unknown":
+        compile_flags.extend([
+            "-mcpu=" + target_cpu_variant,
+            "-mtune=" + target_cpu_variant
+        ])
+    
+    if target_fpu != "unknown":
+        compile_flags.extend([
+            "-mfpu=" + target_fpu
+        ])
+    
+    if target_float_abi != "unknown":
+        compile_flags.extend([
+            "-mfloat-abi=" + target_float_abi
+        ])
 
     dbg_compile_flags = ["-g", "-fstandalone-debug"]
 

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64")]
+SUPPORTED_TARGETS = [("linux", "x86_64", "@platforms//cpu:x86_64"),
+                     ("linux", "aarch64", "@platforms//cpu:aarch64"), 
+                     ("linux", "armv6k", "//platforms:armv6k"),
+                     ("darwin", "x86_64", "@platforms//cpu:x86_64"),
+                     ("darwin", "aarch64", "@platforms//cpu:aarch64")]
 
 host_tool_features = struct(
     SUPPORTS_ARG_FILE = "supports_arg_file",
@@ -100,7 +104,7 @@ def arch(rctx):
 def os_arch_pair(os, arch):
     return "{}-{}".format(os, arch)
 
-_supported_os_arch = [os_arch_pair(os, arch) for (os, arch) in SUPPORTED_TARGETS]
+_supported_os_arch = [os_arch_pair(os, arch) for (os, arch, platform) in SUPPORTED_TARGETS]
 
 def supported_os_arch_keys():
     return _supported_os_arch

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -250,12 +250,18 @@ def _cc_toolchains_str(
 
     cc_toolchains_str = ""
     toolchain_names = []
-    for (target_os, target_arch) in _supported_targets:
+    for (target_os, target_arch, target_platform) in _supported_targets:
         suffix = "{}-{}".format(target_arch, target_os)
+
+        resolved_platform = target_platform
+        if target_platform[0] == "/":
+            resolved_platform = "@{}{}".format(Label("//platforms:BUILD.bazel").workspace_name, target_platform)
+        
         cc_toolchain_str = _cc_toolchain_str(
             suffix,
             target_os,
             target_arch,
+            resolved_platform,
             toolchain_info,
             use_absolute_paths_llvm,
             host_tools_info,
@@ -279,6 +285,7 @@ def _cc_toolchain_str(
         suffix,
         target_os,
         target_arch,
+        target_platform,
         toolchain_info,
         use_absolute_paths_llvm,
         host_tools_info):
@@ -351,7 +358,7 @@ toolchain(
         "@platforms//os:{host_os_bzl}",
     ],
     target_compatible_with = [
-        "@platforms//cpu:{target_arch}",
+        "{target_platform}",
         "@platforms//os:{target_os_bzl}",
     ],
     target_settings = {target_settings},
@@ -456,6 +463,7 @@ cc_toolchain(
         suffix = suffix,
         target_os = target_os,
         target_arch = target_arch,
+        target_platform = target_platform,
         host_os = host_os,
         host_arch = host_arch,
         target_settings = _list_to_string(_dict_value(toolchain_info.target_settings_dict, target_pair)),

--- a/toolchain/internal/sysroot.bzl
+++ b/toolchain/internal/sysroot.bzl
@@ -59,7 +59,7 @@ def _sysroot_path(sysroot_dict, os, arch):
 def sysroot_paths_dict(rctx, sysroot_dict, use_absolute_paths):
     paths_dict = dict()
     labels_dict = dict()
-    for (target_os, target_arch) in _supported_targets:
+    for (target_os, target_arch, target_platform) in _supported_targets:
         path, label = _sysroot_path(
             sysroot_dict,
             target_os,


### PR DESCRIPTION
Allow cpu variants to be specified in platforms/BUILD.bazel that are not part of the standard bazel distribution.
Add optional FPU, Float ABI, and CPU type parameters to set default compile flags for a platform.